### PR TITLE
Hide elements that will conditionally be revealed

### DIFF
--- a/src/views/company/add-step-1.html
+++ b/src/views/company/add-step-1.html
@@ -34,7 +34,7 @@
         {{companyTypeOptions.ukother}}
         <span class="form-hint">UK organisation not registered with Companies House</span>
       </label>
-      <div id="other-uk-type-wrapper" class='panel panel-border-narrow'>
+      <div id="other-uk-type-wrapper" class='panel panel-border-narrow hidden'>
         {{ trade.dropdown("business_type_uk_other",
           label="Type of organisation",
           emptyLabel="Select type",
@@ -47,7 +47,7 @@
         <input id="forother" type="radio" name="business_type" value="forother" {% if company.business_type == "forother" %}checked{% endif %}>
         {{companyTypeOptions.forother}}
       </label>
-      <div id="other-for-type-wrapper" class='panel panel-border-narrow'>
+      <div id="other-for-type-wrapper" class='panel panel-border-narrow hidden'>
         {{ trade.dropdown("business_type_for_other",
           label="Type of organisation",
           emptyLabel="Select type",


### PR DESCRIPTION
If an element is visible and then hidden by JS it can lead to a glitch in rendering. Hiding it using CSS by default and then revealing it still makes it ok for screen readers but saves the flicker.